### PR TITLE
bug fix for setAsDefaultImg

### DIFF
--- a/ll-property-images.html
+++ b/ll-property-images.html
@@ -580,7 +580,7 @@ Example:
         newDefaultId: imageData.detail[1].imgId,
         nodeListAsArray: nodeListAsArray
       };
-      if (nodeListAsArray.length === 2 && imageData.detail[0].imgId === undefined){
+      if (imageData.detail[0].imgId === undefined){
           imagesToUpdate.oldDefaultId = nodeListAsArray[0].imgId;
       }
       this._updateViewForDefaultImage(imagesToUpdate, imageData);

--- a/test/scripts/basic-test.js
+++ b/test/scripts/basic-test.js
@@ -180,9 +180,12 @@ describe('<ll-property-images>', function() {
       detail:
         [oldDefaultImage, newDefaultImage]
     };
+
     var _item = imageData.detail[0]; //id 12345
     var _target = imageData.detail[1]; //id 1234
+
     var nodeListAsArray = [oldDefaultImage, newDefaultImage];
+
     var imagesToUpdate = {
       oldDefaultId: imageData.detail[0].imgId,
       newDefaultId: imageData.detail[1].imgId,
@@ -198,6 +201,41 @@ describe('<ll-property-images>', function() {
     expect(_item.isDefault).to.be.eql(false);
     expect(_target.isDefault).to.be.eql(true);
 
+  });
+
+  it('should check whether currentDefaultImage is not undefined when more than two images exist in NodeList', function() {
+
+    var nodeList = element.querySelectorAll('ll-property-image');
+
+    var oldDefaultImage = {
+      "isDefault": true,
+      "imgId": "5626de2ee2af4d41731ceec0",
+      "fileName": "77733_164312060274756_7884245_o.jpg",
+      "description": "here's a boat, kitty",
+      "categories": [],
+      "title": "a boat",
+      "order": "0"
+    };
+
+    var newDefaultImage = {
+      "imgId": "56291a3bed34778ff696eb2b",
+      "fileName": "musician.jpg",
+      "title": "musician",
+      "description": "play on, playa",
+      "isDefault": false,
+      "order": 0,
+      "categories": []
+    };
+
+    var imageData = {
+      detail:
+        [oldDefaultImage, newDefaultImage]
+    };
+
+    if (nodeList > 2 && element.currentDefaultImage === undefined) {
+      element._updateViewForDefaultImage(imagesToUpdate, imageData);
+      expect(element.currentDefaultImage).to.not.equal(undefined);
+    }
   });
 
 });

--- a/test/scripts/basic-test.js
+++ b/test/scripts/basic-test.js
@@ -203,9 +203,7 @@ describe('<ll-property-images>', function() {
 
   });
 
-  it('should check whether currentDefaultImage is not undefined when more than two images exist in NodeList', function() {
-
-    var nodeList = element.querySelectorAll('ll-property-image');
+  it('should, when currentDefaultImage is undefined, check whether currentDefaultImage gets set to newDefaultImage after calling `_currentDefaultImage()`', function() {
 
     var oldDefaultImage = {
       "isDefault": true,
@@ -232,10 +230,21 @@ describe('<ll-property-images>', function() {
         [oldDefaultImage, newDefaultImage]
     };
 
-    if (nodeList > 2 && element.currentDefaultImage === undefined) {
-      element._updateViewForDefaultImage(imagesToUpdate, imageData);
-      expect(element.currentDefaultImage).to.not.equal(undefined);
-    }
+    var nodeListAsArray = [oldDefaultImage, newDefaultImage];
+
+    var imagesToUpdate = {
+      oldDefaultId: imageData.detail[0].imgId,
+      newDefaultId: imageData.detail[1].imgId,
+      nodeListAsArray: nodeListAsArray
+    };
+
+    var currentDefaultImage = undefined;
+
+    expect(currentDefaultImage).to.equal(undefined);
+    element._updateViewForDefaultImage(imagesToUpdate, imageData);
+    expect(currentDefaultImage).to.equal(element.newDefaultImage);
+
+
   });
 
 });


### PR DESCRIPTION
removes conditional that was verifying only two images existed after the first time a user loads images.
Now a user can load more than two images initially and the `currentDefaultImage` property will still get set.
